### PR TITLE
Two minor fixes for channel probing problem

### DIFF
--- a/_problems/channel-balance-probing.md
+++ b/_problems/channel-balance-probing.md
@@ -127,4 +127,4 @@ An additional line of research here could be using zero-knowledge proofs for pri
 [An Empirical Analysis of Privacy in the Lightning Network]: https://arxiv.org/abs/2003.12470
 [Probing Channel Balances in the Lightning Network]: https://arxiv.org/abs/2004.00333
 [Analysis and Probing of Parallel Channels in the Lightning Network]: https://eprint.iacr.org/2021/384
-[Removing cross-layer links]: removing-cross-layer-links.md
+[Removing cross-layer links]: {% link _problems/removing-cross-layer-links.md %}

--- a/_problems/channel-balance-probing.md
+++ b/_problems/channel-balance-probing.md
@@ -127,3 +127,4 @@ An additional line of research here could be using zero-knowledge proofs for pri
 [An Empirical Analysis of Privacy in the Lightning Network]: https://arxiv.org/abs/2003.12470
 [Probing Channel Balances in the Lightning Network]: https://arxiv.org/abs/2004.00333
 [Analysis and Probing of Parallel Channels in the Lightning Network]: https://eprint.iacr.org/2021/384
+[Removing cross-layer links]: removing-cross-layer-links.md

--- a/_problems/channel-balance-probing.md
+++ b/_problems/channel-balance-probing.md
@@ -7,9 +7,7 @@ maintainer: s-tikhomirov
 issue: 24
 ---
 
-Balances of Lightning channels are not revealed during normal protocol operation. Hence LN users may have a somewhat grounded perception that their balances are private. Indeed, as LN payments are not publicly broadcast (contrary to L1 Bitcoin transactions), Lightning may be seen as not only scalability solution but also a privacy enhancing technology.
-
-In reality, however, channel balance privacy can be violated in the following scenario. The attacker sends a series of payments (probes) with randomly generated payment hashes. Each probe fails because of either insufficient balance at an intermediary hop, or because the final receiver doesn't know the respective preimage. By distinguishing between these two cases, the attacker performs binary search over all possible positions of the balance (between zero and channel capacity).
+Balances of Lightning channels are not revealed during normal protocol operation. Hence LN users may have a somewhat grounded perception that their balances are private. Indeed, as LN payments are not publicly broadcast (contrary to L1 Bitcoin transactions), Lightning may be seen as not only scalability solution but also a privacy enhancing technology. In reality, however, channel balance privacy can be violated in the following scenario. The attacker sends a series of payments (probes) with randomly generated payment hashes. Each probe fails because of either insufficient balance at an intermediary hop, or because the final receiver doesn't know the respective preimage. By distinguishing between these two cases, the attacker performs binary search over all possible positions of the balance (between zero and channel capacity).
 
 {% include figure.html image="probing-attack.svg" name="Channel balance probing attack" caption="The attacker makes a series of probes following the binary search pattern and improves their estimates (colored interval) of the position of the true balance (star) within the channel (outer interval)."
 %}


### PR DESCRIPTION
1. Merge first two paragraphs so that the main page includes the problem definition, not just the background.
2. Add missing link to cross-layer problem (is this how internal links work?)